### PR TITLE
Fix silent reading when more chars come in one event

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -133,7 +133,7 @@ function rawRead (def, timeout, silent, num, cb) {
     var s = decoder.write(c).replace(/\r/g, "\n")
     var i = 0
 
-    LOOP: while (c = s.charAt(i++)) switch (c) {
+    while (c = s.charAt(i++)) switch (c) {
       case "\u007f": // backspace
         val = val.substr(0, val.length - 1)
         if (!silent) process.stdout.write('\b \b')
@@ -164,7 +164,6 @@ function rawRead (def, timeout, silent, num, cb) {
         // explicitly process a delim if we have enough chars
         // and stop the processing.
         if (num && val.length >= num) D("\n")
-        break LOOP
     }
   })
 }


### PR DESCRIPTION
This came up while debugging some strange jitsu issue, where `read`
wouldn't read all chars from a pasted password (only the first one).
Turns out that whole string came in one `data` event and `read`
explicitely `break`s out of the loop after noticing first regular
character.
