### PR TITLE
EventEmitter memory leak

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -65,6 +65,7 @@ function read (opts, cb) {
     rl.close()
     clearTimeout(timer)
     output.mute()
+    m.end()
   }
 
   function onError (er) {


### PR DESCRIPTION
pipe() from mute-stream is called each time Read runs, but the mute-stream is never closed, so if you call Read more than 11 times node throws an EventEmitter memory leak warning onto the console.  I think adding a call to end() of mute-stream in done() would resolve the issue.
