### PR TITLE
Fix extra newline on muted, replaced input

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -98,7 +98,6 @@ function read (opts, cb) {
     if (called) return
     if (silent && terminal) {
       output.unmute()
-      output.write('\r\n')
     }
     done()
     // truncate the \n at the end.


### PR DESCRIPTION
The extra newline is redundant, because a new line character is what is entered in order to terminate input anyway.