### PR TITLE
feat: add completer option to forward to readline

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Every option is optional.
 * `terminal` Treat the output as a TTY, whether it is or not.
 * `input` Readable stream to get input data from. (default `process.stdin`)
 * `output` Writable stream to write prompts to. (default: `process.stdout`)
+* `completer` Autocomplete callback (see [official api](https://nodejs.org/api/readline.html#readline_readline_createinterface_options) for details
 
 If silent is true, and the input is a TTY, then read will set raw
 mode, and read character by character.

--- a/lib/read.js
+++ b/lib/read.js
@@ -5,6 +5,7 @@ module.exports = async function read ({
   default: def = '',
   input = process.stdin,
   output = process.stdout,
+  completer,
   prompt = '',
   silent,
   timeout,
@@ -35,7 +36,7 @@ module.exports = async function read ({
   output = m
 
   return new Promise((resolve, reject) => {
-    const rl = readline.createInterface({ input, output, terminal })
+    const rl = readline.createInterface({ input, output, terminal, silent: true, completer })
     const timer = timeout && setTimeout(() => onError(new Error('timed out')), timeout)
 
     output.unmute()


### PR DESCRIPTION
Author: @131

This is a rebase of https://github.com/npm/read/pull/28 with the test removed.  Testing this requires installing an entirely new pseudo-tty library, and given that the other flags aren't tested that seems like a lot to ask at this point.  We need to readdress testing in general in this repo but this PR is not the place to do it.