### PR TITLE
feat: add `history` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Every option is optional.
 * `input` Readable stream to get input data from. (default `process.stdin`)
 * `output` Writable stream to write prompts to. (default: `process.stdout`)
 * `completer` Autocomplete callback (see [official api](https://nodejs.org/api/readline.html#readline_readline_createinterface_options) for details
+* `history` History array, which will be appended to.
 
 If silent is true, and the input is a TTY, then read will set raw
 mode, and read character by character.

--- a/src/read.ts
+++ b/src/read.ts
@@ -16,6 +16,7 @@ export interface Options<T extends string | number = string> {
     terminal?: boolean
     replace?: string,
     completer?: Completer | AsyncCompleter,
+    history?: string[],
   }
 
 export async function read<T extends string | number = string> ({
@@ -29,6 +30,7 @@ export async function read<T extends string | number = string> ({
   edit,
   terminal,
   replace,
+  history,
 }: Options<T>): Promise<T | string> {
   if (
     typeof def !== 'undefined' &&
@@ -61,7 +63,7 @@ export async function read<T extends string | number = string> ({
   output = m
 
   return new Promise<string | T>((resolve, reject) => {
-    const rl = createInterface({ input, output, terminal, completer })
+    const rl = createInterface({ input, output, terminal, completer, history })
     // TODO: add tests for timeout
     /* c8 ignore start */
     const timer = timeout && setTimeout(() => onError(new Error('timed out')), timeout)


### PR DESCRIPTION
This PR adds support for passing a `history?: string[]` array to `read` as the terminal history, which is then passed to `readline.createInferface()`. (The new history entry will mutate the arrary.) This is very useful for CLIs with an interactive command input.